### PR TITLE
changed to say login link in top `right`

### DIFF
--- a/web/src/views/PreRegister.vue
+++ b/web/src/views/PreRegister.vue
@@ -12,7 +12,7 @@
         </p>
         <p>
           Ready to get started? Use the links below. Use the login link in the
-          top left if you are returning to the service.
+          top right if you are returning to the service.
         </p>
         <v-skeleton-loader boilerplate type="paragraph"></v-skeleton-loader>
         <br />


### PR DESCRIPTION
text says login link is top left, but it's actually top right